### PR TITLE
ci: fix workflow triggers and automate Dependabot merges

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, re-work]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   lint:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,28 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-merge patch and minor updates
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve and enable auto-merge for patch/minor updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem
The default branch is `master`, but `.github/workflows/ci.yml` triggered only on `main`/`re-work`. So **Lint and Test never ran on PRs to `master`** — PR #7 merged with an empty status-check rollup.

## Changes
- **`ci.yml`**: trigger `push`/`pull_request` on `master` so CI actually runs.
- **`dependabot-auto-merge.yml`**: new workflow using `dependabot/fetch-metadata` — auto-approves and enables squash auto-merge for **patch/minor** bumps; **major** upgrades stay manual.
- **`dependabot.yml`**: scheduled weekly version updates for `pip` and `github-actions` (previously only security updates ran).

## Follow-up (applied via API, not in this PR)
- Require `Lint` + `Test` status checks on `master`.
- Enable repo "Allow auto-merge" + delete-branch-on-merge.

Together: a patch/minor Dependabot PR opens → CI runs → auto-approved → auto-merges when green; majors wait for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)